### PR TITLE
Fix: added workaround for default pool management

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ output "ibm_mq_queue_manager_web_url" {
   description = "Queue Manager web URL"
   value       = local.mq_queue_manager_web_url
 }
-
 ```
 
 ### Required IAM access policies

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -3,11 +3,12 @@ package test
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"log"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/gruntwork-io/terratest/modules/logger"
@@ -45,6 +46,12 @@ func setupOptions(t *testing.T, prefix string, exampleDir string) *testhelper.Te
 		TerraformVars: map[string]interface{}{
 			"queue_manager_license":       permanentResources["ibm_mq_queue_manager_license"],
 			"queue_manager_license_usage": permanentResources["ibm_mq_queue_manager_license_usage"],
+		},
+		ImplicitDestroy: []string{
+			// workaround for the issue https://github.ibm.com/GoldenEye/issues/issues/10743
+			// when the issue is fixed on IKS, so the destruction of default workers pool is correctly managed on provider/clusters service the next two entries should be removed
+			"module.ocp_base.ibm_container_vpc_worker_pool.autoscaling_pool[\"default\"]",
+			"module.ocp_base.ibm_container_vpc_worker_pool.pool[\"default\"]",
 		},
 	})
 	return options


### PR DESCRIPTION
### Description

Fix: Added workaround for default pool management in tests

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [X] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Added workaround for default pool management in tests

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
